### PR TITLE
fix connector configuration to use docker network hostname

### DIFF
--- a/scripts/submit_splunksink.sh
+++ b/scripts/submit_splunksink.sh
@@ -7,7 +7,7 @@ DATA=$( cat << EOF
     "connector.class": "com.splunk.kafka.connect.SplunkSinkConnector",
     "topics":"confluent-audit-log-events",
     "splunk.indexes": "main",
-    "splunk.hec.uri" : "https://localhost:8889",
+    "splunk.hec.uri": "https://splunk:8088",
     "splunk.hec.token" : "3bca5f4c-1eff-4eee-9113-ea94c284478a",
     "splunk.sourcetypes"  : "ccloud_audit_logs",
     "confluent.topic.bootstrap.servers"    : "$BOOTSTRAP_SERVERS",


### PR DESCRIPTION
(https://splunk:8088 instead of https://localhost:8889)

to make `scripts/submit_splunksink.sh` configure a working connector for me, I had to change the `localhost` reference to the correct docker network node hostname of `splunk`. This now corresponds to the configuration that is given using the docker-compose-file for the standalone use-case ( `CONNECTOR_SPLUNK_HEC_URI: https://splunk:8088`). 

 

